### PR TITLE
Potential fix for code scanning alert no. 38: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -19,6 +19,9 @@ class ErrorWithParent extends Error {
 module.exports = function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    if (typeof criteria !== 'string') {
+      criteria = ''
+    }
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Pandante-Central/juice-shop/security/code-scanning/38](https://github.com/Pandante-Central/juice-shop/security/code-scanning/38)

To fix this issue, you should enforce that the user-controlled value (`req.query.q`) is a string before applying string methods and further processing. Specifically, after reading the value, check the runtime type: If it is not a string, treat it as invalid or sanitize it to a safe default (e.g., empty string). This check should be added before any string manipulation (length, substring, etc.) on `criteria`. Edit routes/search.ts to add a string type check immediately after reading `criteria` on line 21. No new external libraries are needed; a simple `typeof` check is sufficient. The fix should ensure that if an attacker sends an array, `criteria` is set to an empty string, which is harmless.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
